### PR TITLE
Increase circle vetex limit

### DIFF
--- a/CFG.py
+++ b/CFG.py
@@ -29,7 +29,7 @@ icon_collection = {}
 class TinyCADProperties(bpy.types.PropertyGroup):
 
     num_verts: bpy.props.IntProperty(
-        min=3, max=60, default=12)
+        min=3, max=1000, default=12)
 
     rescale: bpy.props.FloatProperty(
         default=1.0,


### PR DESCRIPTION
60 isn't that many vertices for a circle in CAD.

I needed 400 for something, so picked a thousand as that was a round number which was bigger.